### PR TITLE
Enabling remote api url for client

### DIFF
--- a/client/src/services/AxiosInstance.js
+++ b/client/src/services/AxiosInstance.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import Cookies from "js-cookie";
 
 const AxiosInstance = axios.create({
-    baseURL: process.env.REACT_APP_API_URL || "http://localhost:4000/api",
+    baseURL: process.env.REACT_APP_API_URL || "http://localhost:4000",
     headers: {
         "Content-Type": "application/json",
     },

--- a/client/src/services/AxiosInstance.js
+++ b/client/src/services/AxiosInstance.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import Cookies from "js-cookie";
 
 const AxiosInstance = axios.create({
-    baseURL: "http://localhost:4000",
+    baseURL: process.env.REACT_APP_API_URL || "http://localhost:4000/api",
     headers: {
         "Content-Type": "application/json",
     },


### PR DESCRIPTION
This hotfix allows the client to accept remote api url from .env file